### PR TITLE
fix: Made GH actions filterable (frontend)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,8 +70,8 @@ jobs:
         if: ${{ env.CAN_DO == 'yes' }}
         run: |
           if [[ -z $(git diff --name-only --cached) ]]; then exit 0; fi
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Update modified CDN assets to ${{ env.TAGNAME }}"
           git push origin main
           git tag ${{ env.TAGNAME }}


### PR DESCRIPTION
https://github.com/uBlockOrigin/uAssetsCDN/commits?author=github-actions%20bot -> https://github.com/uBlockOrigin/uAssetsCDN/commits?author=github-actions[bot]
Also allows you to global search filter with `author:github-actions[bot]` or `author:app/github-actions` (prepend `-` to exclude).
Related to https://github.com/uBlockOrigin/uAssets/pull/26608.